### PR TITLE
Add AutoCroesus module

### DIFF
--- a/src/main/kotlin/starred/skies/odin/OdinClient.kt
+++ b/src/main/kotlin/starred/skies/odin/OdinClient.kt
@@ -32,7 +32,7 @@ object OdinClient : ClientModInitializer {
         CloseChest, DungeonAbilities, FuckDiorite, SecretHitboxes, BreakerHelper, KeyHighlight, LividSolver, SpiritBear, TriggerBot,
         Highlight, AutoClicker, Gloomlock, EscrowFix, AutoGFS, QueueTerms, AutoTerms, Trajectories, AutoSell, SimonSays, InventoryWalk,
         FarmKeys, AutoExperiments, EtherwarpHelper, GhostBlock, DoorESP, CancelInteract, WorldScanner, AutoDojo, CheaterWardrobe,
-        CameraHelper, ModSettings, AutoSuperboom, Ghosts, NoGlow
+        CameraHelper, ModSettings, AutoSuperboom, Ghosts, NoGlow, AutoCroesus
     )
 
     private val mainFile: Scribble = Scribble("main")

--- a/src/main/kotlin/starred/skies/odin/features/impl/cheats/AutoCroesus.kt
+++ b/src/main/kotlin/starred/skies/odin/features/impl/cheats/AutoCroesus.kt
@@ -1,0 +1,527 @@
+package starred.skies.odin.features.impl.cheats
+
+import com.odtheking.odin.events.*
+import com.odtheking.odin.events.core.on
+import com.odtheking.odin.features.Module
+import com.odtheking.odin.utils.loreString
+import com.odtheking.odin.utils.modMessage
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.network.chat.Component
+import net.minecraft.world.InteractionHand
+import net.minecraft.world.entity.Entity
+import org.lwjgl.glfw.GLFW
+import starred.skies.odin.helpers.croesus.ChestInfo
+import starred.skies.odin.helpers.croesus.ChestParseResult
+import starred.skies.odin.helpers.croesus.CroesusParser
+import starred.skies.odin.helpers.croesus.PriceClient
+import starred.skies.odin.utils.Skit
+import starred.skies.odin.utils.guiClick
+
+/**
+ * Auto Croesus — highlights unclaimed runs on the top-level Croesus screen,
+ * shows a per-chest cost / value / profit overlay in any run sub-screen, and
+ * (with the module enabled) auto-claims the best chest of every unclaimed run
+ * via the [CLAIM_KEY] keybind.
+ *
+ * Driver flow:
+ *  - In a run sub-screen, press [CLAIM_KEY] -> claims the highest-profit chest.
+ *  - In the top-level Croesus list, press [CLAIM_KEY] -> walks every unclaimed
+ *    run on the current page (open run -> claim best -> back out -> repeat),
+ *    advancing to the next page when the current one is exhausted.
+ *
+ * Deliberately omitted vs. the upstream COP implementation:
+ *  - Kismet reroll layer
+ *  - In-run chain claim (multi-chest per single run)
+ *  - Loot log + persisted loot summary
+ *  - Always-buy / worthless item lists
+ *  - User-configurable settings (everything below is a hardcoded constant).
+ *
+ * Original implementation in COP (GPL-3.0); contributed here under BSD-3-Clause
+ * by the sole author.
+ */
+object AutoCroesus : Module(
+    name = "Auto Croesus",
+    description = "Highlights unclaimed Croesus runs, shows per-chest profit, and (with the module on) auto-claims the best chest of every unclaimed run via the R key.",
+    category = Skit.CHEATS,
+) {
+    // -- Hardcoded constants ---------------------------------------------------
+
+    /** ARGB. Purple, ~70% alpha — outline drawn around runs with unopened chests. */
+    private const val UNCLAIMED_COLOUR_ARGB: Int = 0xB3800080.toInt()
+    /** ARGB. Yellow, ~85% alpha — outline drawn around the best-profit chest icon. */
+    private const val BEST_COLOUR_ARGB: Int = 0xD9FFFF00.toInt()
+    private const val BORDER_WIDTH: Int = 2
+    /** Re-parse the open chest GUI every N ticks. */
+    private const val REFRESH_TICKS: Int = 5
+    /** Refuse to auto-claim if the best chest's profit is below this (raw coins). */
+    private const val MIN_PROFIT: Int = 0
+    /** Abort an in-flight claim if the next screen doesn't appear within N ticks (20 = 1s). */
+    private const val CLAIM_TIMEOUT_TICKS: Int = 60
+    /** Ticks of padding between server actions in multi-run mode. */
+    private const val MULTI_RUN_PACING_TICKS: Long = 6L
+    /** R — keybind that triggers single-run or multi-run claim depending on
+     *  which Croesus screen is currently open. */
+    private const val CLAIM_KEY: Int = GLFW.GLFW_KEY_R
+    /** Safety cap on "Next Page" clicks in a single multi-run cycle. */
+    private const val MAX_PAGES_PER_CYCLE: Int = 5
+
+    // -- Parser cache ----------------------------------------------------------
+
+    @Volatile private var lastChests: List<ChestParseResult> = emptyList()
+    private var cachedContainerId: Int = -1
+    private var ticksSinceParse = 0
+
+    // -- Driver state machine --------------------------------------------------
+
+    private enum class ClaimState {
+        IDLE,
+        /** Sent chest-tier click; waiting for buy-confirm screen to open. */
+        AWAIT_CONFIRM,
+        /** Sent buy click; waiting for next screen (or full menu close, in
+         *  multi-run mode where Hypixel sometimes closes everything). */
+        AWAIT_AFTER_BUY,
+        /** Multi-run: clicked an unclaimed run icon; waiting for the run
+         *  sub-screen to open. */
+        AWAIT_RUN_SCREEN,
+        /** Multi-run: in a freshly-opened run sub-screen; waiting for parser
+         *  data, then auto-claims the best chest. */
+        AWAIT_RUN_CLAIM,
+        /** Multi-run: post-back-out or post-NPC-reopen; waiting for Croesus
+         *  list to populate before scanning for the next unclaimed run. */
+        AWAIT_CROESUS_LIST,
+    }
+    @Volatile private var claimState = ClaimState.IDLE
+    private var monotonicTick = 0L
+    private var claimDeadlineTick = 0L
+    private var pendingTier = ""
+    private var multiRunChestsThisCycle = 0
+    private var multiRunRunsThisCycle = 0
+    private var noScreenSinceTick = 0L
+    private var croesusReadyAtTick = 0L
+    private var pagesVisitedThisCycle = 0
+    /** True while a multi-run cycle is active (set when the user presses the
+     *  key in the Croesus list; cleared by [resetCycle]). */
+    private var multiRunActive = false
+
+    init {
+        //~ if >=1.21.11 'GuiEvent.Close' -> 'ScreenEvent.Close'
+        on<ScreenEvent.Close> {
+            reset()
+            if (claimState == ClaimState.AWAIT_CONFIRM) {
+                modMessage("§7AutoCroesus: GUI closed mid-claim — state reset.")
+                resetCycle()
+            }
+        }
+
+        //~ if >=1.21.11 'GuiEvent.Open' -> 'ScreenEvent.Open'
+        on<ScreenEvent.Open> {
+            reset()
+            when (claimState) {
+                ClaimState.AWAIT_CONFIRM      -> handleConfirmOpen(screen)
+                ClaimState.AWAIT_AFTER_BUY    -> handleAfterBuyOpen(screen)
+                ClaimState.AWAIT_RUN_SCREEN   -> handleRunScreenOpen(screen)
+                ClaimState.AWAIT_CROESUS_LIST -> handleCroesusListOpen(screen)
+                ClaimState.AWAIT_RUN_CLAIM,
+                ClaimState.IDLE -> { /* nothing to do — TickEvent handles these */ }
+            }
+        }
+
+        on<TickEvent.Start> {
+            monotonicTick++
+            if (claimState != ClaimState.IDLE && monotonicTick >= claimDeadlineTick) {
+                modMessage("§cAutoCroesus: timeout (state=$claimState) — aborting.")
+                resetCycle()
+            }
+
+            // Multi-run: after a buy, Hypixel fully closes the menu. Watch for
+            // mc.screen staying null for [MULTI_RUN_PACING_TICKS] before
+            // re-interacting with the Croesus NPC.
+            if (claimState == ClaimState.AWAIT_AFTER_BUY && multiRunActive) {
+                if (mc.screen == null) {
+                    if (noScreenSinceTick == 0L) noScreenSinceTick = monotonicTick
+                    else if (monotonicTick - noScreenSinceTick >= MULTI_RUN_PACING_TICKS) {
+                        noScreenSinceTick = 0L
+                        tryReopenCroesus()
+                    }
+                } else {
+                    noScreenSinceTick = 0L
+                }
+            } else {
+                noScreenSinceTick = 0L
+            }
+
+            val screen = mc.screen as? AbstractContainerScreen<*>
+            if (screen == null) { reset(); return@on }
+
+            // Kick the bulk refresh in the background.
+            PriceClient.refreshIfStale()
+
+            // Multi-run polling: wait for slot data to settle, then advance.
+            if (claimState == ClaimState.AWAIT_CROESUS_LIST &&
+                CroesusParser.inCroesusMenu(screen)) {
+                val slot4 = screen.menu.slots.getOrNull(4)?.item?.isEmpty == false
+                val slot49 = screen.menu.slots.getOrNull(49)?.item?.isEmpty == false
+                val populated = slot4 && slot49
+                if (populated) {
+                    if (croesusReadyAtTick == 0L) croesusReadyAtTick = monotonicTick
+                    if (monotonicTick - croesusReadyAtTick >= MULTI_RUN_PACING_TICKS) {
+                        val unclaimed = CroesusParser.findUnclaimedRunSlots(screen.menu)
+                        if (unclaimed.isNotEmpty()) {
+                            clickUnclaimedRun(unclaimed.first())
+                        } else if (tryAdvancePage(screen)) {
+                            croesusReadyAtTick = 0L
+                        } else {
+                            completeMultiRun()
+                        }
+                        if (claimState != ClaimState.IDLE) croesusReadyAtTick = 0L
+                    }
+                } else {
+                    croesusReadyAtTick = 0L
+                }
+            }
+
+            if (CroesusParser.inRunMenu(screen)) {
+                val cid = screen.menu.containerId
+                if (cid != cachedContainerId) {
+                    lastChests = emptyList()
+                    cachedContainerId = cid
+                    ticksSinceParse = REFRESH_TICKS
+                }
+                ticksSinceParse++
+                if (lastChests.isEmpty() || ticksSinceParse >= REFRESH_TICKS) {
+                    lastChests = CroesusParser.parseChests(screen.menu)
+                    ticksSinceParse = 0
+                }
+
+                // Multi-run: in a freshly-opened run sub-screen, kick off the
+                // claim as soon as parser data is ready.
+                if (claimState == ClaimState.AWAIT_RUN_CLAIM && lastChests.isNotEmpty()) {
+                    claimState = ClaimState.IDLE
+                    tryStartClaim(screen, fromMultiRun = true)
+                }
+            } else if (lastChests.isNotEmpty()) {
+                lastChests = emptyList()
+            }
+        }
+
+        //~ if >=1.21.11 'GuiEvent.DrawSlot' -> 'GuiEvent.RenderSlot'
+        on<GuiEvent.RenderSlot> {
+            val screen = mc.screen as? AbstractContainerScreen<*> ?: return@on
+            when {
+                CroesusParser.inCroesusMenu(screen) -> {
+                    val stack = slot.item.takeUnless { it.isEmpty } ?: return@on
+                    val hasMarker = stack.loreString.any { CroesusParser.LORE_UNCLAIMED_MARKER in it }
+                    if (hasMarker) drawSlotOutline(guiGraphics, slot.x, slot.y, UNCLAIMED_COLOUR_ARGB, BORDER_WIDTH)
+                }
+                CroesusParser.inRunMenu(screen) -> {
+                    val bestSlot = lastChests
+                        .filterIsInstance<ChestParseResult.Success>()
+                        .maxByOrNull { it.chest.profit }
+                        ?.chest?.slot ?: return@on
+                    if (slot.index == bestSlot) {
+                        drawSlotOutline(guiGraphics, slot.x, slot.y, BEST_COLOUR_ARGB, BORDER_WIDTH)
+                    }
+                }
+            }
+        }
+
+        //~ if >=1.21.11 'GuiEvent.Draw' -> 'GuiEvent.Render'
+        on<GuiEvent.Render> {
+            val screen = mc.screen as? AbstractContainerScreen<*> ?: return@on
+            if (!CroesusParser.inRunMenu(screen)) return@on
+            if (lastChests.isEmpty()) return@on
+            renderProfitOverlay(guiGraphics)
+        }
+
+        //~ if >=1.21.11 'GuiEvent.KeyPress' -> 'ScreenEvent.KeyPress'
+        on<ScreenEvent.KeyPress> {
+            if (input.key != CLAIM_KEY) return@on
+            val containerScreen = screen as? AbstractContainerScreen<*> ?: return@on
+
+            if (claimState != ClaimState.IDLE) {
+                modMessage("§cAutoCroesus: already claiming (state=$claimState) — wait or close GUI.")
+                cancel()
+                return@on
+            }
+            when {
+                CroesusParser.inRunMenu(containerScreen)     -> tryStartClaim(containerScreen, fromMultiRun = false)
+                CroesusParser.inCroesusMenu(containerScreen) -> tryStartMultiRun()
+                else -> modMessage("§cAutoCroesus: claim key works only in the Croesus list or a run sub-screen.")
+            }
+            cancel()
+        }
+    }
+
+    // -- ScreenEvent.Open dispatch handlers ------------------------------------
+
+    private fun handleConfirmOpen(screen: Screen) {
+        if (!CroesusParser.inBuyConfirmMenu(screen)) {
+            val title = (screen as? AbstractContainerScreen<*>)?.title?.string ?: "?"
+            modMessage("§cAutoCroesus: aborted — expected buy-confirm, got \"$title\".")
+            resetCycle()
+            return
+        }
+        val container = screen as AbstractContainerScreen<*>
+        if (!clickSlotIn(container, CroesusParser.BUY_CONFIRM_SLOT)) {
+            modMessage("§cAutoCroesus: buy-confirm opened but click failed.")
+            resetCycle()
+            return
+        }
+        multiRunChestsThisCycle++
+        modMessage("§a✓ AutoCroesus: bought §r${pendingTier}§a chest.")
+        if (multiRunActive) {
+            claimState = ClaimState.AWAIT_AFTER_BUY
+            claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+        } else {
+            claimState = ClaimState.IDLE
+        }
+    }
+
+    private fun handleAfterBuyOpen(screen: Screen) {
+        val containerScreen = screen as? AbstractContainerScreen<*> ?: return
+        when {
+            CroesusParser.inRunMenu(containerScreen) -> {
+                // After buying we always leave the run (no in-run chain claim).
+                clickGoBackToList()
+            }
+            CroesusParser.inCroesusMenu(containerScreen) -> {
+                claimState = ClaimState.AWAIT_CROESUS_LIST
+                claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+            }
+            else -> {
+                modMessage("§cAutoCroesus: aborted after buy — unexpected container \"${containerScreen.title.string}\".")
+                resetCycle()
+            }
+        }
+    }
+
+    private fun handleRunScreenOpen(screen: Screen) {
+        if (!CroesusParser.inRunMenu(screen)) {
+            val title = (screen as? AbstractContainerScreen<*>)?.title?.string ?: "?"
+            modMessage("§cAutoCroesus: aborted — expected run sub-screen, got \"$title\".")
+            resetCycle()
+            return
+        }
+        claimState = ClaimState.AWAIT_RUN_CLAIM
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+    }
+
+    private fun handleCroesusListOpen(screen: Screen) {
+        if (!CroesusParser.inCroesusMenu(screen)) {
+            val title = (screen as? AbstractContainerScreen<*>)?.title?.string ?: "?"
+            modMessage("§cAutoCroesus: aborted — expected Croesus list, got \"$title\".")
+            resetCycle()
+            return
+        }
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+    }
+
+    // -- Multi-run helpers -----------------------------------------------------
+
+    private fun clickGoBackToList() {
+        val screen = mc.screen as? AbstractContainerScreen<*> ?: run {
+            modMessage("§cAutoCroesus: no screen to click Go Back on.")
+            resetCycle(); return
+        }
+        if (!clickSlotIn(screen, CroesusParser.RUN_BACK_SLOT)) {
+            modMessage("§cAutoCroesus: failed to click Go Back.")
+            resetCycle()
+            return
+        }
+        claimState = ClaimState.AWAIT_CROESUS_LIST
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+    }
+
+    private fun resetCycle() {
+        claimState = ClaimState.IDLE
+        multiRunChestsThisCycle = 0
+        multiRunRunsThisCycle = 0
+        noScreenSinceTick = 0L
+        croesusReadyAtTick = 0L
+        pagesVisitedThisCycle = 0
+        multiRunActive = false
+    }
+
+    private fun tryReopenCroesus() {
+        val entity = findCroesusEntity()
+        if (entity == null) {
+            completeMultiRun()
+            return
+        }
+        val player = mc.player ?: return
+        mc.gameMode?.interact(player, entity, InteractionHand.MAIN_HAND)
+        claimState = ClaimState.AWAIT_CROESUS_LIST
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 3).toLong()
+    }
+
+    private fun findCroesusEntity(): Entity? {
+        val player = mc.player ?: return null
+        val world = mc.level ?: return null
+        val playerPos = player.position()
+        return world.entitiesForRendering()
+            .asSequence()
+            .filter { e ->
+                if (e === player) return@filter false
+                if (e.position().distanceTo(playerPos) > 6.0) return@filter false
+                val custom = e.customName?.string ?: ""
+                val hover = e.name.string
+                "Croesus" in custom || "Croesus" in hover
+            }
+            .minByOrNull { it.position().distanceTo(playerPos) }
+    }
+
+    private fun tryStartMultiRun() {
+        multiRunChestsThisCycle = 0
+        multiRunRunsThisCycle = 0
+        pagesVisitedThisCycle = 0
+        multiRunActive = true
+        modMessage("§aAutoCroesus: starting multi-run cycle…")
+        claimState = ClaimState.AWAIT_CROESUS_LIST
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+    }
+
+    private fun clickUnclaimedRun(slot: Int): Boolean {
+        val screen = mc.screen as? AbstractContainerScreen<*> ?: return false
+        if (!clickSlotIn(screen, slot)) {
+            modMessage("§cAutoCroesus: failed to click run slot $slot.")
+            resetCycle()
+            return false
+        }
+        multiRunRunsThisCycle++
+        claimState = ClaimState.AWAIT_RUN_SCREEN
+        claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
+        return true
+    }
+
+    private fun tryAdvancePage(screen: AbstractContainerScreen<*>): Boolean {
+        if (pagesVisitedThisCycle >= MAX_PAGES_PER_CYCLE) return false
+        val stack = screen.menu.slots.getOrNull(53)?.item ?: return false
+        if (stack.isEmpty) return false
+        val name = stack.hoverName.string
+        if (!name.contains("Next Page", ignoreCase = true)) return false
+        if (!clickSlotIn(screen, 53)) return false
+        pagesVisitedThisCycle++
+        modMessage("§7AutoCroesus: page exhausted, advancing to page §f${pagesVisitedThisCycle + 1}§7…")
+        return true
+    }
+
+    private fun completeMultiRun() {
+        modMessage(
+            "§aMulti-run complete — bought §f$multiRunChestsThisCycle§a chest" +
+                (if (multiRunChestsThisCycle == 1) "" else "s") + " across " +
+                "§f$multiRunRunsThisCycle§a run" +
+                (if (multiRunRunsThisCycle == 1) "" else "s") + "."
+        )
+        resetCycle()
+    }
+
+    /** Pick the best chest and click it. In multi-run mode, a sub-threshold
+     *  best chest backs out of the run instead of complaining. */
+    private fun tryStartClaim(screen: AbstractContainerScreen<*>, fromMultiRun: Boolean) {
+        if (!CroesusParser.inRunMenu(screen)) {
+            if (!fromMultiRun) modMessage("§cAutoCroesus: claim key only works inside a run sub-screen.")
+            return
+        }
+        val candidates = lastChests
+            .filterIsInstance<ChestParseResult.Success>()
+            .map { it.chest }
+        if (candidates.isEmpty()) {
+            if (!fromMultiRun) modMessage("§cAutoCroesus: no chests parsed yet — wait a moment for the overlay.")
+            return
+        }
+        val best: ChestInfo = candidates.maxByOrNull { it.profit }!!
+        if (best.profit < MIN_PROFIT) {
+            if (fromMultiRun) {
+                modMessage(
+                    "§7Run done — best (§r${best.tierColourCode}${best.tierName}§7) profit " +
+                        "§f${PriceClient.formatPrice(best.profit)}§7 below threshold; backing out."
+                )
+                clickGoBackToList()
+            } else {
+                modMessage(
+                    "§cAutoCroesus: best chest profit §f${PriceClient.formatPrice(best.profit)}§c " +
+                        "below threshold §f${PriceClient.formatPrice(MIN_PROFIT.toDouble())}§c — refusing."
+                )
+            }
+            return
+        }
+        if (!clickSlotIn(screen, best.slot)) {
+            modMessage("§cAutoCroesus: click failed.")
+            return
+        }
+        claimState = ClaimState.AWAIT_CONFIRM
+        claimDeadlineTick = monotonicTick + CLAIM_TIMEOUT_TICKS.toLong()
+        pendingTier = "${best.tierColourCode}${best.tierName}"
+        modMessage(
+            "§aAutoCroesus: claiming ★ §r${pendingTier}§a chest §7(profit ${PriceClient.formatPrice(best.profit)})."
+        )
+    }
+
+    // -- Rendering -------------------------------------------------------------
+
+    private fun reset() {
+        lastChests = emptyList()
+        cachedContainerId = -1
+        ticksSinceParse = 0
+    }
+
+    private fun drawSlotOutline(ctx: GuiGraphics, x: Int, y: Int, colour: Int, bw: Int) {
+        ctx.fill(x - bw, y - bw, x + 16 + bw, y, colour)
+        ctx.fill(x - bw, y + 16, x + 16 + bw, y + 16 + bw, colour)
+        ctx.fill(x - bw, y, x, y + 16, colour)
+        ctx.fill(x + 16, y, x + 16 + bw, y + 16, colour)
+    }
+
+    private fun renderProfitOverlay(ctx: GuiGraphics) {
+        val font = mc.font
+        val x = 4
+        var y = 4
+        val bestSlot = lastChests
+            .filterIsInstance<ChestParseResult.Success>()
+            .maxByOrNull { it.chest.profit }
+            ?.chest?.slot
+        val lines = buildList<Component> {
+            for (result in lastChests) {
+                when (result) {
+                    is ChestParseResult.Success -> {
+                        val c = result.chest
+                        val profitColour = if (c.profit >= 0) "§a+" else "§c"
+                        val marker = if (c.slot == bestSlot) "§e§l★ " else "  "
+                        add(Component.literal(
+                            "$marker${c.tierColourCode}${c.tierName} Chest §7(${PriceClient.formatPrice(c.cost)}) " +
+                                "$profitColour${PriceClient.formatPrice(c.profit)}"
+                        ))
+                        for (item in c.items.take(6)) {
+                            val v = item.unitValue * item.qty
+                            val vColour = if (v > 0) "§a" else "§7"
+                            val name = item.displayName.removePrefix("§5§o")
+                            add(Component.literal("    $name $vColour${PriceClient.formatPrice(v)}"))
+                        }
+                        if (c.items.size > 6) add(Component.literal("    §7… +${c.items.size - 6} more"))
+                        add(Component.literal(""))
+                    }
+                    is ChestParseResult.Failure -> {
+                        add(Component.literal("  §c${result.tierName} Chest §7(${result.reason})"))
+                        add(Component.literal(""))
+                    }
+                }
+            }
+        }
+        if (lines.isEmpty()) return
+        val maxWidth = lines.maxOf { font.width(it) }
+        val totalHeight = lines.size * (font.lineHeight + 1) + 6
+        ctx.fill(x - 2, y - 2, x + maxWidth + 4, y + totalHeight, 0xC0000000.toInt())
+        for (line in lines) {
+            ctx.drawString(font, line, x, y, 0xFFFFFFFF.toInt(), false)
+            y += font.lineHeight + 1
+        }
+    }
+
+    private fun clickSlotIn(screen: AbstractContainerScreen<*>, slot: Int): Boolean {
+        val containerId = screen.menu.containerId
+        guiClick(containerId, slot)
+        return true
+    }
+}

--- a/src/main/kotlin/starred/skies/odin/features/impl/cheats/AutoCroesus.kt
+++ b/src/main/kotlin/starred/skies/odin/features/impl/cheats/AutoCroesus.kt
@@ -263,12 +263,7 @@ object AutoCroesus : Module(
             resetCycle()
             return
         }
-        val container = screen as AbstractContainerScreen<*>
-        if (!clickSlotIn(container, CroesusParser.BUY_CONFIRM_SLOT)) {
-            modMessage("§cAutoCroesus: buy-confirm opened but click failed.")
-            resetCycle()
-            return
-        }
+        clickSlotIn(screen as AbstractContainerScreen<*>, CroesusParser.BUY_CONFIRM_SLOT)
         multiRunChestsThisCycle++
         modMessage("§a✓ AutoCroesus: bought §r${pendingTier}§a chest.")
         if (multiRunActive) {
@@ -325,11 +320,7 @@ object AutoCroesus : Module(
             modMessage("§cAutoCroesus: no screen to click Go Back on.")
             resetCycle(); return
         }
-        if (!clickSlotIn(screen, CroesusParser.RUN_BACK_SLOT)) {
-            modMessage("§cAutoCroesus: failed to click Go Back.")
-            resetCycle()
-            return
-        }
+        clickSlotIn(screen, CroesusParser.RUN_BACK_SLOT)
         claimState = ClaimState.AWAIT_CROESUS_LIST
         claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
     }
@@ -382,26 +373,23 @@ object AutoCroesus : Module(
         claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
     }
 
-    private fun clickUnclaimedRun(slot: Int): Boolean {
-        val screen = mc.screen as? AbstractContainerScreen<*> ?: return false
-        if (!clickSlotIn(screen, slot)) {
-            modMessage("§cAutoCroesus: failed to click run slot $slot.")
-            resetCycle()
-            return false
-        }
+    private fun clickUnclaimedRun(slot: Int) {
+        val screen = mc.screen as? AbstractContainerScreen<*> ?: return
+        clickSlotIn(screen, slot)
         multiRunRunsThisCycle++
         claimState = ClaimState.AWAIT_RUN_SCREEN
         claimDeadlineTick = monotonicTick + (CLAIM_TIMEOUT_TICKS * 2).toLong()
-        return true
     }
 
+    /** Returns true if a "Next Page" click was sent (so the caller knows the
+     *  Croesus list isn't actually exhausted yet). */
     private fun tryAdvancePage(screen: AbstractContainerScreen<*>): Boolean {
         if (pagesVisitedThisCycle >= MAX_PAGES_PER_CYCLE) return false
         val stack = screen.menu.slots.getOrNull(53)?.item ?: return false
         if (stack.isEmpty) return false
         val name = stack.hoverName.string
         if (!name.contains("Next Page", ignoreCase = true)) return false
-        if (!clickSlotIn(screen, 53)) return false
+        clickSlotIn(screen, 53)
         pagesVisitedThisCycle++
         modMessage("§7AutoCroesus: page exhausted, advancing to page §f${pagesVisitedThisCycle + 1}§7…")
         return true
@@ -447,10 +435,7 @@ object AutoCroesus : Module(
             }
             return
         }
-        if (!clickSlotIn(screen, best.slot)) {
-            modMessage("§cAutoCroesus: click failed.")
-            return
-        }
+        clickSlotIn(screen, best.slot)
         claimState = ClaimState.AWAIT_CONFIRM
         claimDeadlineTick = monotonicTick + CLAIM_TIMEOUT_TICKS.toLong()
         pendingTier = "${best.tierColourCode}${best.tierName}"
@@ -459,13 +444,15 @@ object AutoCroesus : Module(
         )
     }
 
-    // -- Rendering -------------------------------------------------------------
-
+    /** Drop the parser cache when the container changes — stale data from the
+     *  previous run would otherwise leak into the next overlay. */
     private fun reset() {
         lastChests = emptyList()
         cachedContainerId = -1
         ticksSinceParse = 0
     }
+
+    // -- Rendering -------------------------------------------------------------
 
     private fun drawSlotOutline(ctx: GuiGraphics, x: Int, y: Int, colour: Int, bw: Int) {
         ctx.fill(x - bw, y - bw, x + 16 + bw, y, colour)
@@ -519,9 +506,7 @@ object AutoCroesus : Module(
         }
     }
 
-    private fun clickSlotIn(screen: AbstractContainerScreen<*>, slot: Int): Boolean {
-        val containerId = screen.menu.containerId
-        guiClick(containerId, slot)
-        return true
+    private fun clickSlotIn(screen: AbstractContainerScreen<*>, slot: Int) {
+        guiClick(screen.menu.containerId, slot)
     }
 }

--- a/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusModels.kt
+++ b/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusModels.kt
@@ -1,0 +1,32 @@
+package starred.skies.odin.helpers.croesus
+
+/** A single line of loot inside a Croesus chest. `displayName` keeps the
+ *  original formatted lore line (§ codes intact) so the overlay can render it
+ *  the same colour Hypixel showed it. */
+data class RewardItem(
+    val skyblockId: String,
+    val qty: Int,
+    val unitValue: Double,
+    val displayName: String,
+)
+
+/** A single chest tier (Wood / Gold / Diamond / Emerald / Obsidian / Bedrock)
+ *  inside a Croesus run, parsed from its tooltip. */
+data class ChestInfo(
+    val slot: Int,
+    val tierName: String,
+    val tierColourCode: String,
+    val cost: Double,
+    val items: List<RewardItem>,
+    val totalValue: Double,
+) {
+    val profit: Double get() = totalValue - cost
+}
+
+/** What the parser could not resolve — surfaced to the overlay so users can see
+ *  which lore line broke the chest's profit calc instead of silently dropping
+ *  the chest entirely. */
+sealed class ChestParseResult {
+    data class Success(val chest: ChestInfo) : ChestParseResult()
+    data class Failure(val tierName: String, val reason: String) : ChestParseResult()
+}

--- a/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusParser.kt
+++ b/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusParser.kt
@@ -52,8 +52,6 @@ object CroesusParser {
 
     /** "Open Reward Chest" in the buy-confirm screen. */
     const val BUY_CONFIRM_SLOT: Int = 31
-    /** "Go Back" in the buy-confirm screen. */
-    const val BUY_BACK_SLOT: Int = 49
     /** "Go Back" in the run sub-screen. */
     const val RUN_BACK_SLOT: Int = 30
 
@@ -68,18 +66,6 @@ object CroesusParser {
     fun inBuyConfirmMenu(screen: Screen?): Boolean =
         screen is AbstractContainerScreen<*> &&
             BUY_CONFIRM_TITLE_REGEX.matches(screen.title.string.trim())
-
-    /** Parse the chest currently displayed in the buy-confirm screen.
-     *  Returns null when [title] isn't a recognised tier. */
-    fun parseBuyConfirmChest(menu: AbstractContainerMenu, title: String): ChestParseResult? {
-        val tierName = title.trim()
-        val colourCode = TIER_COLOUR_CODE[tierName] ?: return null
-        val lorePlain = lorePlain(menu, BUY_CONFIRM_SLOT)
-            ?: return ChestParseResult.Failure(tierName, "buy-confirm slot $BUY_CONFIRM_SLOT empty")
-        val loreFormatted = loreFormatted(menu, BUY_CONFIRM_SLOT)
-            ?: return ChestParseResult.Failure(tierName, "buy-confirm slot $BUY_CONFIRM_SLOT empty")
-        return parseChestLore(BUY_CONFIRM_SLOT, tierName, colourCode, lorePlain, loreFormatted)
-    }
 
     // -- Run-selection screen ---------------------------------------------------
 
@@ -248,7 +234,7 @@ object CroesusParser {
     // -- Helpers ----------------------------------------------------------------
 
     /** Lore lines with § codes preserved (needed for ultimate-book detection). */
-    fun loreFormatted(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
+    private fun loreFormatted(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
         val stack = menu.slots.getOrNull(slotIndex)?.item ?: return null
         if (stack.isEmpty) return null
         val lines = stack.lore.takeIf { it.isNotEmpty() } ?: return null
@@ -256,7 +242,7 @@ object CroesusParser {
     }
 
     /** Lore lines with all formatting stripped. */
-    fun lorePlain(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
+    private fun lorePlain(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
         val stack = menu.slots.getOrNull(slotIndex)?.item ?: return null
         if (stack.isEmpty) return null
         return stack.loreString.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusParser.kt
+++ b/src/main/kotlin/starred/skies/odin/helpers/croesus/CroesusParser.kt
@@ -1,0 +1,283 @@
+package starred.skies.odin.helpers.croesus
+
+import com.odtheking.odin.utils.lore
+import com.odtheking.odin.utils.loreString
+import net.minecraft.ChatFormatting
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.Style
+import net.minecraft.world.inventory.AbstractContainerMenu
+import java.util.Optional
+
+/**
+ * Read-only parser for the Croesus NPC's GUIs.
+ *
+ *  - [inCroesusMenu]   — top-level run-selection screen (title "Croesus").
+ *  - [inRunMenu]       — a single-run sub-screen ("Catacombs - Floor X" or
+ *                        "Master Catacombs - Floor X").
+ *  - [findUnclaimedRunSlots] — which slots on the run-selection screen still
+ *                        have unopened chests, for the overlay highlight.
+ *  - [parseChests]     — read every tier's tooltip, decode contents + cost,
+ *                        look prices up via [PriceClient], return one
+ *                        [ChestInfo] per tier.
+ *
+ * Adapted from the ChatTriggers AutoCroesus module
+ * (github.com/UnclaimedBloom6/RandomStuff/tree/main/AutoCroesus). Lore-shape
+ * regexes (chest tier names, "Cost"/"FREE" sentinels, the "No chests opened
+ * yet!" unclaimed marker) come straight from there; the regex format is
+ * dictated by Hypixel's actual tooltip text.
+ *
+ * Item-ID resolution covers enchanted books, essences, and anything else with
+ * a registered display name in the Hypixel items registry.
+ */
+object CroesusParser {
+
+    /** A run still has unopened chests if any tooltip line contains this
+     *  substring (plain text, formatting stripped). */
+    const val LORE_UNCLAIMED_MARKER: String = "No chests opened yet"
+
+    private val CHEST_TITLE_REGEX = Regex("^(Wood|Gold|Diamond|Emerald|Obsidian|Bedrock)(?: Chest)?$")
+    private val COST_REGEX = Regex("^([\\d,]+) Coins$")
+    private const val COST_FREE = "FREE"
+
+    private val BOOK_REGEX_FORMATTED = Regex(
+        "^(?:§.)*Enchanted Book \\((§d§l)?([\\w ]+) (\\w+)(?:§.)*\\)\$"
+    )
+    private val ESSENCE_REGEX = Regex("^(\\w+) Essence x(\\d+)$")
+    private val NUMERAL_VALUES = mapOf('I' to 1, 'V' to 5, 'X' to 10, 'L' to 50, 'C' to 100, 'D' to 500, 'M' to 1000)
+
+    private val RUN_TITLE_REGEX = Regex("^(?:Master )?Catacombs - .+$")
+    private val BUY_CONFIRM_TITLE_REGEX = Regex("^(Wood|Gold|Diamond|Emerald|Obsidian|Bedrock)$")
+
+    /** "Open Reward Chest" in the buy-confirm screen. */
+    const val BUY_CONFIRM_SLOT: Int = 31
+    /** "Go Back" in the buy-confirm screen. */
+    const val BUY_BACK_SLOT: Int = 49
+    /** "Go Back" in the run sub-screen. */
+    const val RUN_BACK_SLOT: Int = 30
+
+    // -- GUI detection ----------------------------------------------------------
+
+    fun inCroesusMenu(screen: Screen?): Boolean =
+        screen is AbstractContainerScreen<*> && screen.title.string.trim() == "Croesus"
+
+    fun inRunMenu(screen: Screen?): Boolean =
+        screen is AbstractContainerScreen<*> && RUN_TITLE_REGEX.matches(screen.title.string.trim())
+
+    fun inBuyConfirmMenu(screen: Screen?): Boolean =
+        screen is AbstractContainerScreen<*> &&
+            BUY_CONFIRM_TITLE_REGEX.matches(screen.title.string.trim())
+
+    /** Parse the chest currently displayed in the buy-confirm screen.
+     *  Returns null when [title] isn't a recognised tier. */
+    fun parseBuyConfirmChest(menu: AbstractContainerMenu, title: String): ChestParseResult? {
+        val tierName = title.trim()
+        val colourCode = TIER_COLOUR_CODE[tierName] ?: return null
+        val lorePlain = lorePlain(menu, BUY_CONFIRM_SLOT)
+            ?: return ChestParseResult.Failure(tierName, "buy-confirm slot $BUY_CONFIRM_SLOT empty")
+        val loreFormatted = loreFormatted(menu, BUY_CONFIRM_SLOT)
+            ?: return ChestParseResult.Failure(tierName, "buy-confirm slot $BUY_CONFIRM_SLOT empty")
+        return parseChestLore(BUY_CONFIRM_SLOT, tierName, colourCode, lorePlain, loreFormatted)
+    }
+
+    // -- Run-selection screen ---------------------------------------------------
+
+    fun findUnclaimedRunSlots(menu: AbstractContainerMenu): List<Int> {
+        val out = mutableListOf<Int>()
+        val end = (menu.slots.size - 36).coerceAtMost(54)
+        for (i in 0 until end) {
+            val lore = lorePlain(menu, i) ?: continue
+            if (lore.any { LORE_UNCLAIMED_MARKER in it }) out += i
+        }
+        return out
+    }
+
+    private val TIER_COLOUR_CODE = mapOf(
+        "Wood" to "§7", "Gold" to "§6", "Diamond" to "§b",
+        "Emerald" to "§a", "Obsidian" to "§5", "Bedrock" to "§c",
+    )
+
+    // -- Run sub-screen ---------------------------------------------------------
+
+    fun parseChests(menu: AbstractContainerMenu): List<ChestParseResult> {
+        val results = mutableListOf<ChestParseResult>()
+        val end = (menu.slots.size - 36).coerceAtMost(27)
+        for (i in 0 until end) {
+            val slot = menu.slots.getOrNull(i) ?: continue
+            val stack = slot.item ?: continue
+            if (stack.isEmpty) continue
+
+            val plainName = stack.hoverName.string.trim()
+            val titleMatch = CHEST_TITLE_REGEX.matchEntire(plainName) ?: continue
+            val tierName = titleMatch.groupValues[1]
+            val colourCode = TIER_COLOUR_CODE[tierName] ?: "§7"
+
+            val lorePlain = lorePlain(menu, i) ?: run {
+                results += ChestParseResult.Failure(tierName, "no lore"); continue
+            }
+            val loreFormatted = loreFormatted(menu, i) ?: run {
+                results += ChestParseResult.Failure(tierName, "no lore"); continue
+            }
+            results += parseChestLore(i, tierName, colourCode, lorePlain, loreFormatted)
+        }
+        return results
+    }
+
+    private fun parseChestLore(
+        slot: Int,
+        tierName: String,
+        colourCode: String,
+        lorePlain: List<String>,
+        loreFormatted: List<String>,
+    ): ChestParseResult {
+        if (lorePlain.any {
+                val s = it.lowercase()
+                "already bought" in s || "already opened" in s
+            }) {
+            return ChestParseResult.Failure(tierName, "already bought")
+        }
+
+        val costIdx = lorePlain.indexOfFirst { it.trim() == "Cost" }
+        if (costIdx < 0 || costIdx + 1 >= lorePlain.size) {
+            return ChestParseResult.Failure(tierName, "no Cost marker in lore")
+        }
+        val costLine = lorePlain[costIdx + 1].trim()
+        val cost = parseCost(costLine)
+            ?: return ChestParseResult.Failure(tierName, "unparseable cost: \"$costLine\"")
+
+        val blankIdx = costIdx - 1
+        if (blankIdx < 1 || lorePlain[blankIdx].isNotBlank()) {
+            return ChestParseResult.Failure(tierName, "no blank separator before Cost (idx=$blankIdx)")
+        }
+        val lastItem = blankIdx - 1
+        val firstItem = 1
+        if (firstItem > lastItem) {
+            return ChestParseResult.Success(ChestInfo(slot, tierName, colourCode, cost, emptyList(), 0.0))
+        }
+
+        val items = mutableListOf<RewardItem>()
+        var totalValue = 0.0
+        for (i in firstItem..lastItem) {
+            val plain = lorePlain.getOrNull(i)?.trim() ?: continue
+            if (plain.isEmpty()) continue
+            val formatted = loreFormatted.getOrNull(i) ?: plain
+            val (id, qty) = tryParseLine(plain, formatted)
+            val price = priceFor(id)
+            items += RewardItem(id, qty, price, formatted)
+            totalValue += price * qty
+        }
+        val sorted = items.sortedByDescending { it.unitValue * it.qty }
+        return ChestParseResult.Success(
+            ChestInfo(slot, tierName, colourCode, cost, sorted, totalValue)
+        )
+    }
+
+    private fun priceFor(id: String): Double {
+        if (id.startsWith("ENCHANTMENT_")) {
+            val rest = id.removePrefix("ENCHANTMENT_").removePrefix("ULTIMATE_")
+            val lastUnderscore = rest.lastIndexOf('_')
+            if (lastUnderscore > 0) {
+                val name = rest.substring(0, lastUnderscore)
+                val lvl = rest.substring(lastUnderscore + 1).toIntOrNull() ?: 1
+                PriceClient.getEnchantBookPrice(name, lvl)?.let { return it }
+            }
+        }
+        PriceClient.getBazaarSell(id)?.let { return it }
+        PriceClient.getLowestBin(id)?.let { return it }
+        PriceClient.ensureLowestBin(id)
+        return 0.0
+    }
+
+    private fun parseCost(line: String): Double? {
+        if (line.equals(COST_FREE, ignoreCase = true)) return 0.0
+        val m = COST_REGEX.matchEntire(line) ?: return null
+        return m.groupValues[1].replace(",", "").toDoubleOrNull()
+    }
+
+    // -- Single-line parsing (book / essence / item) ----------------------------
+
+    private fun tryParseLine(plain: String, formatted: String): Pair<String, Int> {
+        tryParseBook(formatted)?.let { return it }
+        tryParseEssence(plain)?.let { return it }
+
+        val qtyMatch = Regex("^(.+?) x(\\d+)$").matchEntire(plain)
+        val (namePart, qty) = if (qtyMatch != null) {
+            qtyMatch.groupValues[1] to qtyMatch.groupValues[2].toInt()
+        } else plain to 1
+
+        val id = PriceClient.resolveItemId(namePart)
+            ?: PriceClient.resolveShardId(namePart)
+            ?: namePart.uppercase().replace(' ', '_').replace("'", "")
+        return id to qty
+    }
+
+    private fun tryParseBook(formatted: String): Pair<String, Int>? {
+        val m = BOOK_REGEX_FORMATTED.matchEntire(formatted) ?: return null
+        val ultPrefix = m.groupValues[1]
+        val rawName = m.groupValues[2]
+        val tierStr = m.groupValues[3]
+
+        val tier = tierStr.toIntOrNull() ?: decodeRoman(tierStr) ?: return null
+        val ultimate = ultPrefix.isNotEmpty()
+        val nameUpper = rawName.uppercase().replace(' ', '_')
+        val id = ("ENCHANTMENT_" + (if (ultimate && !nameUpper.startsWith("ULTIMATE_")) "ULTIMATE_" else "") + nameUpper + "_$tier")
+            .replace("ULTIMATE_ULTIMATE_", "ULTIMATE_")
+        return id to 1
+    }
+
+    private fun tryParseEssence(plain: String): Pair<String, Int>? {
+        val m = ESSENCE_REGEX.matchEntire(plain.trim()) ?: return null
+        val type = m.groupValues[1].uppercase()
+        val qty = m.groupValues[2].toIntOrNull() ?: 1
+        return "ESSENCE_$type" to qty
+    }
+
+    private fun decodeRoman(numeral: String): Int? {
+        if (numeral.isEmpty() || numeral.any { it !in NUMERAL_VALUES }) return null
+        var sum = 0
+        var i = 0
+        while (i < numeral.length) {
+            val curr = NUMERAL_VALUES[numeral[i]]!!
+            val next = if (i + 1 < numeral.length) NUMERAL_VALUES[numeral[i + 1]] ?: 0 else 0
+            if (curr < next) { sum += next - curr; i += 2 } else { sum += curr; i++ }
+        }
+        return sum
+    }
+
+    // -- Helpers ----------------------------------------------------------------
+
+    /** Lore lines with § codes preserved (needed for ultimate-book detection). */
+    fun loreFormatted(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
+        val stack = menu.slots.getOrNull(slotIndex)?.item ?: return null
+        if (stack.isEmpty) return null
+        val lines = stack.lore.takeIf { it.isNotEmpty() } ?: return null
+        return lines.map { it.formattedString }
+    }
+
+    /** Lore lines with all formatting stripped. */
+    fun lorePlain(menu: AbstractContainerMenu, slotIndex: Int): List<String>? {
+        val stack = menu.slots.getOrNull(slotIndex)?.item ?: return null
+        if (stack.isEmpty) return null
+        return stack.loreString.takeIf { it.isNotEmpty() }
+    }
+
+    /** Walks a Component tree and rebuilds the legacy-encoded string with §
+     *  colour / format codes. Needed because Hypixel ships lore as proper
+     *  Components but parseBook compares against `§d§l` prefixes. */
+    private val Component.formattedString: String get() = buildString {
+        val rgbMap = ChatFormatting.entries
+            .mapNotNull { it.color?.let { color -> color to it } }
+            .toMap()
+        visit<Unit>({ style, content ->
+            style.color?.value?.let { rgbMap[it]?.let(::append) }
+            if (style.isBold) append(ChatFormatting.BOLD)
+            if (style.isItalic) append(ChatFormatting.ITALIC)
+            if (style.isUnderlined) append(ChatFormatting.UNDERLINE)
+            if (style.isStrikethrough) append(ChatFormatting.STRIKETHROUGH)
+            if (style.isObfuscated) append(ChatFormatting.OBFUSCATED)
+            append(content)
+            Optional.empty()
+        }, Style.EMPTY)
+    }
+}

--- a/src/main/kotlin/starred/skies/odin/helpers/croesus/PriceClient.kt
+++ b/src/main/kotlin/starred/skies/odin/helpers/croesus/PriceClient.kt
@@ -1,0 +1,193 @@
+package starred.skies.odin.helpers.croesus
+
+import com.google.gson.JsonParser
+import com.odtheking.odin.OdinMod
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Reads three public Hypixel-adjacent price/registry endpoints and caches the
+ * results in memory for ~30 minutes. Pure read-only utility used by Auto Croesus.
+ *
+ * Endpoints
+ *  - Bazaar (instant-sell prices for bazaar items)
+ *  - SkyCofl per-item BIN (lowest BIN for non-bazaar items)
+ *  - Hypixel items registry (display-name -> item id)
+ */
+object PriceClient {
+    private const val URL_BAZAAR        = "https://api.hypixel.net/skyblock/bazaar"
+    private const val URL_ITEMS         = "https://api.hypixel.net/v2/resources/skyblock/items"
+    /** Per-item SkyCofl BIN endpoint — primary LBIN source. Returns a JSON array
+     *  of active BIN auctions; lowest BIN per unit = min(startingBid / count). */
+    private const val URL_SKYCOFL_BIN_F = "https://sky.coflnet.com/api/auctions/tag/%s/active/bin"
+
+    const val DEFAULT_REFRESH_MS: Long = 30L * 60 * 1000
+    private const val LBIN_TTL_MS: Long = 10L * 60 * 1000
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val bazaarSell = ConcurrentHashMap<String, Double>()
+    private val bazaarBuy  = ConcurrentHashMap<String, Double>()
+    private val lowestBin  = ConcurrentHashMap<String, Double>()
+    private val lowestBinFetchedAt = ConcurrentHashMap<String, Long>()
+    private val lbinInFlight = ConcurrentHashMap.newKeySet<String>()
+    private val nameToId   = ConcurrentHashMap<String, String>()
+
+    @Volatile private var lastRefreshedAt = 0L
+    @Volatile var lastError: String? = null; private set
+    private val refreshMutex = Mutex()
+
+    val ageMs: Long get() = if (lastRefreshedAt == 0L) Long.MAX_VALUE else System.currentTimeMillis() - lastRefreshedAt
+
+    fun getBazaarSell(itemId: String): Double? = bazaarSell[itemId]
+    fun getBazaarBuy(itemId: String): Double? = bazaarBuy[itemId]
+    fun getLowestBin(itemId: String): Double? = lowestBin[itemId]
+
+    fun resolveItemId(displayName: String): String? =
+        nameToId[displayName.trim().lowercase()]
+
+    /** Map a Galatea / Hunting-Box shard display name to its bazaar id.
+     *  "Power Dragon Shard" -> "SHARD_POWER_DRAGON". The items-registry endpoint
+     *  doesn't include these (it stops at the pre-Galatea era). */
+    fun resolveShardId(displayName: String): String? {
+        val trimmed = displayName.trim()
+        val withoutSuffix = when {
+            trimmed.endsWith(" Shards", ignoreCase = true) -> trimmed.dropLast(7).trim()
+            trimmed.endsWith(" Shard", ignoreCase = true)  -> trimmed.dropLast(6).trim()
+            else -> return null
+        }
+        if (withoutSuffix.isEmpty()) return null
+        val candidate = "SHARD_" + withoutSuffix.uppercase().replace(' ', '_').replace("'", "")
+        return if (bazaarSell.containsKey(candidate) || bazaarBuy.containsKey(candidate)) candidate else null
+    }
+
+    /** Human-readable price, the way Hypixel shows coins. */
+    fun formatPrice(price: Double): String {
+        val abs = kotlin.math.abs(price)
+        val l = java.util.Locale.US
+        return when {
+            abs >= 1_000_000_000_000.0 -> "%.2fT".format(l, price / 1_000_000_000_000.0)
+            abs >= 1_000_000_000.0     -> "%.2fB".format(l, price / 1_000_000_000.0)
+            abs >= 1_000_000.0         -> "%.2fM".format(l, price / 1_000_000.0)
+            else                       -> "%,d".format(l, price.toLong())
+        }
+    }
+
+    /** Bazaar instant-sell price for the enchant book matching the given NBT
+     *  enchant key (e.g. `sharpness`, `ultimate_combo`) at the given level. */
+    fun getEnchantBookPrice(enchantName: String, level: Int): Double? {
+        val name = enchantName.uppercase()
+        bazaarSell["ENCHANTMENT_${name}_$level"]?.let { return it }
+        if (!name.startsWith("ULTIMATE_")) {
+            bazaarSell["ENCHANTMENT_ULTIMATE_${name}_$level"]?.let { return it }
+        }
+        return null
+    }
+
+    /** Fire-and-forget: ensure this item's LBIN is fresh. Cheap when cached,
+     *  deduped when in flight — safe to call every frame from the overlay. */
+    fun ensureLowestBin(itemId: String) {
+        if (itemId.isBlank()) return
+        val age = lowestBinFetchedAt[itemId] ?: 0L
+        if (System.currentTimeMillis() - age < LBIN_TTL_MS) return
+        if (!lbinInFlight.add(itemId)) return
+        scope.launch {
+            try {
+                fetchSkyCoflLowestBin(itemId)?.let {
+                    lowestBin[itemId] = it
+                    lowestBinFetchedAt[itemId] = System.currentTimeMillis()
+                }
+            } catch (t: Throwable) {
+                OdinMod.logger.warn("[AutoCroesus] SkyCofl LBIN fetch failed for $itemId: ${t.message}")
+            } finally {
+                lbinInFlight.remove(itemId)
+            }
+        }
+    }
+
+    /** Kick off an async refresh if the bulk cache is older than [maxAgeMs]. */
+    fun refreshIfStale(maxAgeMs: Long = DEFAULT_REFRESH_MS) {
+        if (ageMs < maxAgeMs) return
+        scope.launch {
+            refreshMutex.withLock {
+                if (ageMs < maxAgeMs) return@withLock
+                val errors = mutableListOf<String>()
+                runCatching { fetchBazaar() }      .onFailure { errors += "bazaar: ${it.message ?: it.javaClass.simpleName}" }
+                runCatching { fetchItemRegistry() }.onFailure { errors += "items: ${it.message ?: it.javaClass.simpleName}" }
+                val anySucceeded = bazaarSell.isNotEmpty() || nameToId.isNotEmpty()
+                if (anySucceeded) lastRefreshedAt = System.currentTimeMillis()
+                lastError = if (errors.isEmpty()) null else errors.joinToString("; ")
+                if (errors.isNotEmpty()) OdinMod.logger.warn("[AutoCroesus] PriceClient partial: $lastError")
+            }
+        }
+    }
+
+    private fun openJsonGet(url: String): HttpURLConnection {
+        val conn = URI(url).toURL().openConnection() as HttpURLConnection
+        conn.requestMethod = "GET"
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 20_000
+        conn.setRequestProperty("Accept", "application/json")
+        conn.setRequestProperty("User-Agent", "OdinClient-AutoCroesus/1.0")
+        return conn
+    }
+
+    private fun fetchBazaar() {
+        val conn = openJsonGet(URL_BAZAAR)
+        conn.inputStream.use { stream ->
+            val root = JsonParser.parseReader(InputStreamReader(stream)).asJsonObject
+            check(root.get("success")?.asBoolean == true) { "success=false" }
+            val products = root.getAsJsonObject("products") ?: return
+            bazaarSell.clear()
+            bazaarBuy.clear()
+            for ((id, json) in products.entrySet()) {
+                val qs = json.asJsonObject.getAsJsonObject("quick_status") ?: continue
+                qs.get("sellPrice")?.asDouble?.let { bazaarSell[id] = it }
+                qs.get("buyPrice")?.asDouble?.let { bazaarBuy[id] = it }
+            }
+        }
+    }
+
+    private fun fetchSkyCoflLowestBin(itemId: String): Double? {
+        val url = URL_SKYCOFL_BIN_F.format(itemId)
+        val conn = openJsonGet(url)
+        conn.inputStream.use { stream ->
+            val root = JsonParser.parseReader(InputStreamReader(stream))
+            if (!root.isJsonArray) return null
+            var minPerItem = Double.MAX_VALUE
+            for (el in root.asJsonArray) {
+                val obj = el.asJsonObject
+                val count = obj.get("count")?.asInt ?: 1
+                val bid = obj.get("startingBid")?.asDouble ?: continue
+                if (count <= 0 || bid <= 0) continue
+                val perItem = bid / count
+                if (perItem < minPerItem) minPerItem = perItem
+            }
+            return if (minPerItem != Double.MAX_VALUE) minPerItem else null
+        }
+    }
+
+    private fun fetchItemRegistry() {
+        val conn = openJsonGet(URL_ITEMS)
+        conn.inputStream.use { stream ->
+            val root = JsonParser.parseReader(InputStreamReader(stream)).asJsonObject
+            check(root.get("success")?.asBoolean == true) { "success=false" }
+            val items = root.getAsJsonArray("items") ?: return
+            nameToId.clear()
+            for (el in items) {
+                val obj = el.asJsonObject
+                val id = obj.get("id")?.asString ?: continue
+                val name = obj.get("name")?.asString ?: continue
+                nameToId[name.trim().lowercase()] = id
+            }
+        }
+    }
+}

--- a/src/main/kotlin/starred/skies/odin/helpers/croesus/PriceClient.kt
+++ b/src/main/kotlin/starred/skies/odin/helpers/croesus/PriceClient.kt
@@ -42,13 +42,12 @@ object PriceClient {
     private val nameToId   = ConcurrentHashMap<String, String>()
 
     @Volatile private var lastRefreshedAt = 0L
-    @Volatile var lastError: String? = null; private set
+    @Volatile private var lastError: String? = null
     private val refreshMutex = Mutex()
 
-    val ageMs: Long get() = if (lastRefreshedAt == 0L) Long.MAX_VALUE else System.currentTimeMillis() - lastRefreshedAt
+    private val ageMs: Long get() = if (lastRefreshedAt == 0L) Long.MAX_VALUE else System.currentTimeMillis() - lastRefreshedAt
 
     fun getBazaarSell(itemId: String): Double? = bazaarSell[itemId]
-    fun getBazaarBuy(itemId: String): Double? = bazaarBuy[itemId]
     fun getLowestBin(itemId: String): Double? = lowestBin[itemId]
 
     fun resolveItemId(displayName: String): String? =


### PR DESCRIPTION
## Summary

Adds an **Auto Croesus** module under *Cheats*.

- Highlights every run with unopened chests on the top-level Croesus screen (purple outline).
- In a run sub-screen, draws a per-chest overlay with cost / total value / profit, marks the best chest with a yellow outline + ★.
- Auto-claims the best chest of every unclaimed run, driven from a single keybind.

## Usage

1. Enable **Auto Croesus** in the click GUI.
2. Walk to the Croesus NPC and right-click to open the menu.
3. Press **R** while inside a Croesus GUI:
   - **In a run sub-screen** (e.g. `Catacombs - Floor VII`) → claims the highest-profit chest.
   - **In the top-level Croesus list** → starts the multi-run cycle: opens each unclaimed run, claims the best chest, backs out, re-interacts with the NPC, repeats. Advances to the next page when the current one is exhausted.

The "Keybind" field shown in OdinClient's module GUI is the standard module-toggle keybind (every module has one), **not** the claim trigger. The claim key is hardcoded to R.

Prices come from a small in-process price client (Hypixel Bazaar + Hypixel items registry + SkyCofl per-item LBIN), cached for ~30 min and refreshed lazily.

## Configuration

The only user-facing knob is the module's enabled toggle. Everything else is a hardcoded constant at the top of `AutoCroesus.kt`:

| Constant | Value |
|---|---|
| Unclaimed-run highlight | purple, 2px outline |
| Best-chest highlight | yellow, 2px outline |
| Refresh rate | 5 ticks |
| Claim keybind | R |
| Min profit | 0 (claims any non-negative chest) |
| Claim timeout | 60 ticks |
| Multi-run pacing | 6 ticks |

Happy to expose any of these as proper settings if you'd prefer — let me know which.

## Deliberately omitted vs. the upstream COP implementation

- **Kismet reroll layer** — speculative-buy + feather-consume reroll path.
- **In-run chain claim** — claiming multiple chests within a single run (multi-run across runs is kept).
- **Loot log + persisted summary** — no on-disk write, no `/cop loot`-style command.
- **Always-buy / worthless item lists** — no marginal-chest override.
- **Debug GUI dump key.**

Easy to add any of these back if wanted — stripped to keep the PR small.

## License

Original implementation in [COP](https://github.com/elv1n200/COP) (GPL-3.0); contributed here under BSD-3-Clause by the sole author.

## Files

- `features/impl/cheats/AutoCroesus.kt` — module + driver state machine + overlay/outline rendering.
- `helpers/croesus/CroesusParser.kt` — read-only parsing of the Croesus / run-sub-screen / buy-confirm GUIs.
- `helpers/croesus/CroesusModels.kt` — `ChestInfo` / `RewardItem` / `ChestParseResult` data classes.
- `helpers/croesus/PriceClient.kt` — Bazaar + items registry bulk fetch + per-item SkyCofl LBIN fallback.
- `OdinClient.kt` — registered `AutoCroesus` in `modulesToRegister`.

## Test plan

- [x] Builds cleanly for both stonecutter targets (`./gradlew build` on 1.21.10 and 1.21.11).
- [x] Validated in-game on Hypixel: pressed R in the Croesus list → multi-run cycle ran through every unclaimed run, claimed best chest in each, backed out, advanced pages, and printed `Multi-run complete — bought N chests across M runs`.

Happy to adjust based on maintainer preferences.