### PR TITLE
Fixes issue where autoclicker fails to start via this error string

### DIFF
--- a/src/main/java/foo/starred/odinclient/mixin/accessors/KeyMappingAccessor.java
+++ b/src/main/java/foo/starred/odinclient/mixin/accessors/KeyMappingAccessor.java
@@ -2,10 +2,11 @@ package foo.starred.odinclient.mixin.accessors;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.ToggleKeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(KeyMapping.class)
+@Mixin({ KeyMapping.class, ToggleKeyMapping.class })
 public interface KeyMappingAccessor {
     @Accessor("clickCount")
     int getClickCount();

--- a/src/main/kotlin/foo/starred/odinclient/utils/PlayerUtils.kt
+++ b/src/main/kotlin/foo/starred/odinclient/utils/PlayerUtils.kt
@@ -1,21 +1,23 @@
 package foo.starred.odinclient.utils
 
+import com.mojang.blaze3d.platform.InputConstants
 import com.odtheking.odin.OdinMod.mc
 import net.minecraft.client.KeyMapping
 import net.minecraft.world.inventory.ContainerInput
 import foo.starred.odinclient.mixin.accessors.KeyMappingAccessor
 
+private fun KeyMapping.boundKey(): InputConstants.Key? =
+    (this as? KeyMappingAccessor)?.boundKey
+
 fun rightClick() {
-    val options = mc.options ?: return
-    val key = (options.keyUse as KeyMappingAccessor).boundKey
+    val key = mc.options?.keyUse?.boundKey() ?: return
     KeyMapping.set(key, true)
     KeyMapping.click(key)
     KeyMapping.set(key, false)
 }
 
 fun leftClick() {
-    val options = mc.options ?: return
-    val key = (options.keyAttack as KeyMappingAccessor).boundKey
+    val key = mc.options?.keyAttack?.boundKey() ?: return
     KeyMapping.set(key, true)
     KeyMapping.click(key)
     KeyMapping.set(key, false)


### PR DESCRIPTION
0.2.2 Caught an ClassCastException at Start. \n

```
class net.minecraft.client.ToggleKeyMapping cannot be cast to class foo.starred.odinclient.mixin.accessors.KeyMappingAccessor (net.minecraft.client.ToggleKeyMapping and foo.starred.odinclient.mixin.accessors.KeyMappingAccessor are in unnamed module of loader 'Genesis' @672f75e8) \njava.lang.ClassCastException: class net.minecraft.client.ToggleKeyMapping cannot be cast to class foo.starred.odinclient.mixin.accessors.KeyMappingAccessor (net.minecraft.client.ToggleKeyMapping and foo.starred.odinclient.mixin.accessors.KeyMappingAccessor are in unnamed module of loader 'Genesis' @672f75e8)
	at Genesis//foo.starred.odinclient.utils.PlayerUtilsKt.leftClick(PlayerUtils.kt:18)
	at Genesis//foo.starred.odinclient.features.impl.cheats.AutoClicker$1.invoke(AutoClicker.kt:91)
	at Genesis//foo.starred.odinclient.features.impl.cheats.AutoClicker$1.invoke(AutoClicker.kt:54)
	at Genesis//foo.starred.odinclient.features.impl.cheats.AutoClicker$special$$inlined$on$default$1.invoke(EventBus.kt:144)
	at Genesis//foo.starred.odinclient.features.impl.cheats.AutoClicker$special$$inlined$on$default$1.invoke(EventBus.kt:143)
	at Genesis//com.odtheking.odin.events.core.EventBus$EventListener.invoke(EventBus.kt:109)
	at Genesis//com.odtheking.odin.events.core.EventBus$InvokerFactory$build$1.invoke(EventBus.kt:128)
	at Genesis//com.odtheking.odin.events.core.EventBus.post(EventBus.kt:42)
	at Genesis//com.odtheking.odin.events.core.Event.postAndCatch(Event.kt:9)
```